### PR TITLE
Remove Rosetta2 Requirements and Update Required macOS Version

### DIFF
--- a/Casks/pixelflasher.rb
+++ b/Casks/pixelflasher.rb
@@ -2,7 +2,7 @@ cask "pixelflasher" do
   version "7.9.1.1"
   sha256 "3b4628ba12bf5914d212a4d6e588b78d7045bd3673b71ea12ed2e9f17bc73a7b"
 
-  url "https://github.com/badabing2005/PixelFlasher/releases/download/v#{version}/PixelFlasher(macOS 11+).dmg"
+  url "https://github.com/badabing2005/PixelFlasher/releases/download/v#{version}/PixelFlasher_MacOS.dmg"
   name "PixelFlasher"
   desc "Pixel phone flashing GUI utility with features"
   homepage "https://github.com/badabing2005/PixelFlasher"

--- a/Casks/pixelflasher.rb
+++ b/Casks/pixelflasher.rb
@@ -12,7 +12,7 @@ cask "pixelflasher" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :big_sur"
 
   app "PixelFlasher.app"
 

--- a/Casks/pixelflasher.rb
+++ b/Casks/pixelflasher.rb
@@ -2,7 +2,7 @@ cask "pixelflasher" do
   version "7.9.1.1"
   sha256 "3b4628ba12bf5914d212a4d6e588b78d7045bd3673b71ea12ed2e9f17bc73a7b"
 
-  url "https://github.com/badabing2005/PixelFlasher/releases/download/v#{version}/PixelFlasher.dmg"
+  url "https://github.com/badabing2005/PixelFlasher/releases/download/v#{version}/PixelFlasher(macOS 11+).dmg"
   name "PixelFlasher"
   desc "Pixel phone flashing GUI utility with features"
   homepage "https://github.com/badabing2005/PixelFlasher"

--- a/Casks/pixelflasher.rb
+++ b/Casks/pixelflasher.rb
@@ -21,8 +21,4 @@ cask "pixelflasher" do
     "~/Library/Preferences/com.badabing.pixelflasher.plist",
     "~/Library/Saved Application State/com.badabing.pixelflasher.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Remove Rosetta2 Requirements as it's not needed. badabing2005/PixelFlasher#267