### PR TITLE
Update cask for new homebrew format

### DIFF
--- a/Casks/pixelflasher.rb
+++ b/Casks/pixelflasher.rb
@@ -12,7 +12,7 @@ cask "pixelflasher" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "PixelFlasher.app"
 


### PR DESCRIPTION
Proposed change is due to Homebrew warning on macOS:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
> Please report this issue to the badabing2005/homebrew-pixelflasher tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
>  /opt/homebrew/Library/Taps/badabing2005/homebrew-pixelflasher/Casks/pixelflasher.rb:15